### PR TITLE
Prevent death creators from triggering multiple times

### DIFF
--- a/Kuggen2077-real/Assets/Scripts/Handlers/RecieveAttackHandler.cs
+++ b/Kuggen2077-real/Assets/Scripts/Handlers/RecieveAttackHandler.cs
@@ -24,11 +24,15 @@ public class RecieveAttackHandler {
             creators.Activate(attack);
         }
         Attackable.CurrentHitPoints -= attack.Damage;
+
         if (Attackable.CurrentHitPoints <= 0) {
-			foreach(RecieveAttackEffectCreator death in DeathCreators) {
-				death.Activate(attack);
-			}
 			Die();
+
+			if (Attackable.CurrentHitPoints == 0) {
+				foreach (RecieveAttackEffectCreator death in DeathCreators) {
+					death.Activate (attack);
+				}
+			}
         }
     }
 


### PR DESCRIPTION
Quick fix to make sure that multiple shots landing on an enemy in the same frame won't trigger the death effects multiple times. Feel free to suggest a better solution.